### PR TITLE
fix: dag-pb nodes can’t be copied

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,11 @@ class Block {
     return this.opts.source
   }
 
+  _clone (obj) {
+    if (this.codec !== 'dag-pb') return clone(obj)
+    else return obj
+  }
+
   async cid () {
     if (this.opts.cid) return this.opts.cid
     const codec = this.codec
@@ -95,7 +100,7 @@ class Block {
 
   decode () {
     if (!this._decoded) this._decode()
-    return clone(this._decoded)
+    return this._clone(this._decoded)
   }
 
   decodeUnsafe () {

--- a/index.js
+++ b/index.js
@@ -48,11 +48,6 @@ class Block {
     return this.opts.source
   }
 
-  _clone (obj) {
-    if (this.codec !== 'dag-pb') return clone(obj)
-    else return obj
-  }
-
   async cid () {
     if (this.opts.cid) return this.opts.cid
     const codec = this.codec
@@ -96,11 +91,13 @@ class Block {
     const codec = module.exports.getCodec(this.codec)
     if (this.opts.source) this._decoded = this.opts.source
     else this._decoded = codec.decode(this._encoded || this.opts.data)
+    return this._decoded
   }
 
   decode () {
+    if (this.codec === 'dag-pb') return this._decode()
     if (!this._decoded) this._decode()
-    return this._clone(this._decoded)
+    return clone(this._decoded)
   }
 
   decodeUnsafe () {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "aegir": "^20.2.0",
     "hundreds": "0.0.2",
+    "ipld-dag-pb": "^0.18.1",
     "tsame": "^2.0.1"
   },
   "dependencies": {

--- a/test/block.spec.js
+++ b/test/block.spec.js
@@ -5,6 +5,8 @@ const dagjson = require('@ipld/dag-json')
 const assert = require('assert')
 const tsame = require('tsame')
 const CID = require('cids')
+const dagPB = require('ipld-dag-pb')
+const DAGNode = dagPB.DAGNode
 
 const same = (...args) => assert.ok(tsame(...args))
 const test = it
@@ -109,5 +111,15 @@ test('decode deep object', done => {
   const block = Block.encoder(o, 'dag-json')
   const decoded = block.decode()
   same(decoded, o)
+  done()
+})
+
+test('dag-pb encode/decode', done => {
+  const node = new DAGNode(Buffer.from('some data'))
+  const block = Block.encoder(node, 'dag-pb')
+  const encoded = block.encode()
+  const decoded = block.decode()
+  same(encoded, Block.decoder(encoded, 'dag-pb').encode())
+  same(decoded._data, Buffer.from('some data'))
   done()
 })


### PR DESCRIPTION
Carson found a good bug in the new safe/unsafe release. `dag-pb` nodes aren’t data model so they don’t return simple types and therefor can’t actually be cloned nicely. this PR special cases `dag-pb` in order to fix.