### PR TITLE
fix: blocks w/ immutable types don't clone

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,8 +98,8 @@ class Block {
   decode () {
     if (this.codec === 'dag-pb') return this._decode()
     if (!this._decoded) this._decode()
-    const tt = this._decoded
-    if (typeof tt === 'number' || typeof tt === 'boolean') {
+    const tt = typeof this._decoded
+    if (tt === 'number' || tt === 'boolean') {
       // return any immutable types
       return this._decoded
     }

--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ const clone = obj => transform(obj, (result, value, key) => {
 class Block {
   constructor (opts) {
     if (!opts) throw new Error('Block options are required')
-    if (!opts.source && !opts.data) {
+    if (typeof opts.source === 'undefined' &&
+        typeof opts.data === 'undefined') {
       throw new Error('Block instances must be created with either an encode source or data')
     }
     if (opts.source && !opts.codec) {
@@ -97,6 +98,12 @@ class Block {
   decode () {
     if (this.codec === 'dag-pb') return this._decode()
     if (!this._decoded) this._decode()
+    const tt = this._decoded
+    if (typeof tt === 'number' || typeof tt === 'boolean') {
+      // return any immutable types
+      return this._decoded
+    }
+    if (Buffer.isBuffer(this._decoded)) return Buffer.from(this._decoded)
     return clone(this._decoded)
   }
 

--- a/tests/test-block.js
+++ b/tests/test-block.js
@@ -114,6 +114,22 @@ test('decode deep object', done => {
   done()
 })
 
+test('decode of immutable types', done => {
+  let block = Block.encoder(1, 'dag-json')
+  same(block.decode(), 1)
+  block = Block.encoder(true, 'dag-json')
+  same(block.decode(), true)
+  done()
+})
+
+test('safe clone of buffers', done => {
+  const block = Block.encoder(Buffer.from('test'), 'raw')
+  const decoded = block.decode()
+  decoded[0] = 'd'.charCodeAt(0)
+  same(block.decode().toString(), 'test')
+  done()
+})
+
 test('dag-pb encode/decode', done => {
   const node = new DAGNode(Buffer.from('some data'))
   const block = Block.encoder(node, 'dag-pb')


### PR DESCRIPTION
Merging this quickly as it’s a hot fix for something we broke with the new *safe APIs.