### PR TITLE
wip: migrate to latest multiformats

### DIFF
--- a/basics.js
+++ b/basics.js
@@ -1,6 +1,0 @@
-import multiformats from 'multiformats/basics'
-import create from './index.js'
-
-const Block = create(multiformats)
-
-export default Block

--- a/defaults.js
+++ b/defaults.js
@@ -1,5 +1,6 @@
-import Block from './basics.js'
-import dagcbor from '@ipld/dag-cbor'
-Block.multiformats.multicodec.add(dagcbor)
+import Block from './index.js'
+import { codec as multicodec } from 'multiformats'
+import * as dagcbor from '@ipld/dag-cbor'
+Block.add(multicodec.codec(dagcbor))
 
 export default Block

--- a/index.js
+++ b/index.js
@@ -1,174 +1,221 @@
-import withIs from 'class-is'
 import transform from 'lodash.transform'
 import createReader from './reader.js'
+import json from 'multiformats/codecs/json'
+import raw from 'multiformats/codecs/raw'
+import { sha256 } from 'multiformats/hashes/sha2'
+import { bytes, CID } from 'multiformats'
 
 const readonly = value => ({ get: () => value, set: () => { throw new Error('Cannot set read-only property') } })
 
 const immutableTypes = new Set(['number', 'string', 'boolean'])
 
-const create = multiformats => {
-  const { bytes, CID, multihash, multicodec } = multiformats
-  const { coerce, isBinary } = bytes
-  const copyBinary = value => {
-    const b = coerce(value)
-    return coerce(b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength))
-  }
-  const reader = createReader(multiformats)
+const { coerce, isBinary } = bytes
+const copyBinary = value => {
+  const b = coerce(value)
+  return coerce(b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength))
+}
+const reader = createReader(CID)
 
-  const clone = obj => transform(obj, (result, value, key) => {
-    const cid = CID.asCID(value)
-    if (cid) {
-      result[key] = cid
-    } else if (isBinary(value)) {
-      result[key] = copyBinary(value)
-    } else if (typeof value === 'object' && value !== null) {
-      result[key] = clone(value)
+const clone = obj => transform(obj, (result, value, key) => {
+  if (value && value.asCID === value) {
+    result[key] = value
+  } else if (isBinary(value)) {
+    result[key] = copyBinary(value)
+  } else if (typeof value === 'object' && value !== null) {
+    result[key] = clone(value)
+  } else {
+    result[key] = value
+  }
+})
+
+class Block {
+  constructor (opts) {
+    if (!opts) throw new Error('Block options are required')
+    if (opts.codec) {
+      if (typeof opts.codec !== 'object') {
+        const codec = Block.codecs.get(opts.codec)
+        if (!opts.codec) throw new Error(`Cannot find codec ${JSON.stringify(opts.codec)}`)
+        opts.codec = codec
+      }
     } else {
-      result[key] = value
+      if (!opts.cid) throw new Error('Cannot create block instance without cid or codec')
+      opts.codec = Block.codecs.get(opts.cid.code)
     }
-  })
-
-  class Block {
-    constructor (opts) {
-      if (!opts) throw new Error('Block options are required')
-      if (opts.cid) opts.cid = CID.asCID(opts.cid)
-      if (typeof opts.codec === 'number') {
-        opts.code = opts.codec
-        opts.codec = multicodec.get(opts.code).name
-      }
-      if (typeof opts.source === 'undefined' &&
-          typeof opts.data === 'undefined') {
-        throw new Error('Block instances must be created with either an encode source or data')
-      }
-      if (typeof opts.source !== 'undefined' && !opts.codec && !opts.code) {
-        throw new Error('Block instances created from source objects must include desired codec')
-      }
-      if (opts.data && !opts.cid && !opts.codec && !opts.code) {
-        throw new Error('Block instances created from data must include cid or codec')
-      }
-      if (!opts.cid && !opts.algo) opts.algo = 'sha2-256'
-      // Do our best to avoid accidental mutations of the options object after instantiation
-      // Note: we can't actually freeze the object because we mutate it once per property later
-      opts = Object.assign({}, opts)
-      Object.defineProperty(this, 'opts', readonly(opts))
+    if (typeof opts.source === 'undefined' &&
+        typeof opts.data === 'undefined') {
+      throw new Error('Block instances must be created with either an encode source or data')
     }
-
-    source () {
-      if (this.opts.cid || this.opts.data ||
-          this._encoded || this._decoded) return null
-      if (!this.opts.source) return null
-      return this.opts.source
+    if (typeof opts.source !== 'undefined' && !opts.codec && !opts.code) {
+      throw new Error('Block instances created from source objects must include desired codec')
     }
-
-    async cid () {
-      if (this.opts.cid) return this.opts.cid
-      const hash = await multihash.hash(this.encodeUnsafe(), this.opts.algo)
-      const cid = CID.create(1, this.code, hash)
-      this.opts.cid = cid
-      // https://github.com/bcoe/c8/issues/135
-      /* c8 ignore next */
-      return cid
+    if (opts.data && !opts.cid && !opts.codec && !opts.code) {
+      throw new Error('Block instances created from data must include cid or codec')
     }
-
-    get codec () {
-      if (this.opts.code) {
-        this.opts.codec = multicodec.get(this.opts.code).name
-      }
-      if (this.opts.cid) {
-        this.opts.codec = multicodec.get(this.opts.cid.code).name
-      }
-      return this.opts.codec
-    }
-
-    get code () {
-      if (this.opts.cid) return this.opts.cid.code
-      if (!this.opts.code) {
-        this.opts.code = multicodec.get(this.codec).code
-      }
-      return this.opts.code
-    }
-
-    async validate () {
-      // if we haven't created a CID yet we know it will be valid :)
-      if (!this.opts.cid) return true
-      const cid = await this.cid()
-      const data = this.encodeUnsafe()
-      // https://github.com/bcoe/c8/issues/135
-      /* c8 ignore next */
-      return multihash.validate(cid.multihash, data)
-    }
-
-    _encode () {
-      this._encoded = this.opts.data || multicodec.get(this.code).encode(this.opts.source)
-    }
-
-    encode () {
-      if (!this._encoded) this._encode()
-      return copyBinary(this._encoded)
-    }
-
-    encodeUnsafe () {
-      if (!this._encoded) this._encode()
-      return this._encoded
-    }
-
-    _decode () {
-      if (typeof this.opts.source !== 'undefined') this._decoded = this.opts.source
-      else {
-        const { decode } = multicodec.get(this.code)
-        this._decoded = decode(this._encoded || this.opts.data)
-      }
-      return this._decoded
-    }
-
-    decode () {
-      // TODO: once we upgrade to the latest data model version of
-      // dag-pb that @gozala wrote we should be able to remove this
-      // and treat it like every other codec.
-      /* c8 ignore next */
-      if (this.codec === 'dag-pb') return this._decode()
-      if (!this._decoded) this._decode()
-      const tt = typeof this._decoded
-      if (tt === 'number' || tt === 'boolean') {
-        // return any immutable types
-        return this._decoded
-      }
-      if (isBinary(this._decoded)) return copyBinary(this._decoded)
-      if (immutableTypes.has(typeof this._decoded) || this._decoded === null) {
-        return this._decoded
-      }
-      return clone(this._decoded)
-    }
-
-    decodeUnsafe () {
-      if (!this._decoded) this._decode()
-      return this._decoded
-    }
-
-    reader () {
-      return reader(this.decodeUnsafe())
-    }
-
-    async equals (block) {
-      if (block === this) return true
-      const cid = await this.cid()
-      if (CID.asCID(block)) return cid.equals(CID.asCID(block))
-      // https://github.com/bcoe/c8/issues/135
-      /* c8 ignore next */
-      return cid.equals(await block.cid())
-    }
+    opts.hasher = opts.hasher || sha256
+    // Do our best to avoid accidental mutations of the options object after instantiation
+    // Note: we can't actually freeze the object because we mutate it once per property later
+    opts = Object.assign({}, opts)
+    Object.defineProperty(this, 'opts', readonly(opts))
+    Object.defineProperty(this, 'asBlock', readonly(this))
   }
 
-  const BlockWithIs = withIs(Block, { className: 'Block', symbolName: '@ipld/block' })
-  BlockWithIs.encoder = (source, codec, algo) => new BlockWithIs({ source, codec, algo })
-  BlockWithIs.decoder = (data, codec, algo) => new BlockWithIs({ data, codec, algo })
-  BlockWithIs.create = (data, cid) => {
-    if (typeof cid === 'string') cid = CID.from(cid)
-    return new BlockWithIs({ data, cid })
+  get hasher () {
+    if (this.opts.cid) {
+      if (!this.opts.hasher) {
+        this.opts.hasher = Block.codecs.get(this.opts.cid.multihash.code)
+      } else if (this.opts.hasher.code !== this.opts.cid.multihash.code) {
+        this.opts.hasher = Block.codecs.get(this.opts.cid.multihash.code)
+      } else {
+        return this.opts.hasher || sha256
+      }
+      if (!this.opts.hasher) throw new Error('Do not have hash implementation')
+    }
+    return this.opts.hasher || sha256
   }
-  BlockWithIs.multiformats = multiformats
-  BlockWithIs.CID = CID
-  return BlockWithIs
+
+  source () {
+    if (this.opts.cid || this.opts.data ||
+        this._encoded || this._decoded) return null
+    if (!this.opts.source) return null
+    return this.opts.source
+  }
+
+  async cid () {
+    if (this.opts.cid) return this.opts.cid
+    const hash = await this.hasher.digest(this.encodeUnsafe())
+    const cid = CID.create(1, this.opts.codec.code, hash)
+    this.opts.cid = cid
+    // https://github.com/bcoe/c8/issues/135
+    /* c8 ignore next */
+    return cid
+  }
+
+  get codec () {
+    if (this.opts.cid) {
+      if (!this.opts.codec || this.opts.codec.code !== this.opts.cid.code) {
+        this.opts.codec = Block.codecs.get(this.opts.cid.code)
+      }
+    } else if (this.opts.code) {
+      this.opts.codec = Block.codecs.get(this.opts.code)
+    }
+    return this.opts.codec.name
+  }
+
+  get code () {
+    if (this.opts.cid) return this.opts.cid.code
+    if (!this.opts.code) {
+      this.opts.code = this.opts.codec.code
+    }
+    return this.opts.code
+  }
+
+  async validate () {
+    // if we haven't created a CID yet we know it will be valid :)
+    if (!this.opts.cid) return true
+    if (!this.opts.hasher) throw new Error('Must have hasher in order to perform comparison')
+    const cid = await this.cid()
+    const data = this.encodeUnsafe()
+    const hash = await this.hasher.digest(data)
+    if (bytes.equals(cid.multihash.bytes, hash.bytes)) return true
+    throw new Error('Bytes do not match')
+  }
+
+  _encode () {
+    if (!this.opts.data && !this.opts.codec) {
+      throw new Error('Do not have codec implemention in this Block interface')
+    }
+    this._encoded = this.opts.data || this.opts.codec.encode(this.opts.source)
+  }
+
+  encode () {
+    if (!this._encoded) this._encode()
+    return copyBinary(this._encoded)
+  }
+
+  encodeUnsafe () {
+    if (!this._encoded) this._encode()
+    return this._encoded
+  }
+
+  _decode () {
+    if (typeof this.opts.source !== 'undefined') this._decoded = this.opts.source
+    else {
+      this._decoded = this.opts.codec.decode(this._encoded || this.opts.data)
+    }
+    return this._decoded
+  }
+
+  decode () {
+    // TODO: once we upgrade to the latest data model version of
+    // dag-pb that @gozala wrote we should be able to remove this
+    // and treat it like every other codec.
+    /* c8 ignore next */
+    if (this.codec === 'dag-pb') return this._decode()
+    if (!this._decoded) this._decode()
+    const tt = typeof this._decoded
+    if (tt === 'number' || tt === 'boolean') {
+      // return any immutable types
+      return this._decoded
+    }
+    if (isBinary(this._decoded)) return copyBinary(this._decoded)
+    if (immutableTypes.has(typeof this._decoded) || this._decoded === null) {
+      return this._decoded
+    }
+    return clone(this._decoded)
+  }
+
+  decodeUnsafe () {
+    if (!this._decoded) this._decode()
+    return this._decoded
+  }
+
+  reader () {
+    return reader(this.decodeUnsafe())
+  }
+
+  async equals (block) {
+    if (block === this) return true
+    const cid = await this.cid()
+    if (block.asCID === block) return cid.equals(block)
+    // https://github.com/bcoe/c8/issues/135
+    /* c8 ignore next */
+    return cid.equals(await block.cid())
+  }
 }
 
-export default create
+Block.codecs = new Map()
+
+Block.add = codec => {
+  if (codec.name) Block.codecs.set(codec.name, codec)
+  if (codec.code) Block.codecs.set(codec.code, codec)
+}
+Block.add(json)
+Block.add(raw)
+
+Block.encoder = (source, codec, hasher) => new Block({ source, codec, hasher })
+Block.decoder = (data, codec, hasher) => new Block({ data, codec, hasher })
+Block.create = (data, cid) => {
+  if (typeof cid === 'string') cid = CID.parse(cid)
+  const codec = Block.codecs.get(cid.code)
+  return new Block({ data, cid, codec })
+}
+Block.defaults = opts => ({
+  CID,
+  defaults: opts,
+  encoder: (source, codec, hasher) => new Block({
+    source,
+    codec: codec || opts.codec,
+    hasher: hasher || opts.hasher
+  }),
+  decoder: (data, codec, hasher) => new Block({
+    data,
+    codec: codec || opts.codec,
+    hasher: hasher || opts.hasher
+  }),
+  create: Block.create,
+  codecs: Block.codecs,
+  add: Block.add
+})
+Block.CID = CID
+
+export default Block

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "standard": "^14.3.4"
   },
   "dependencies": {
-    "@ipld/dag-cbor": "1.1.11",
+    "@ipld/dag-cbor": "2.0.2",
     "class-is": "^1.1.0",
     "lodash.transform": "^4.6.0",
-    "multiformats": "^3.0.3"
+    "multiformats": "^4.0.0"
   },
   "repository": {
     "type": "git",
@@ -42,9 +42,6 @@
   "exports": {
     ".": {
       "import": "./index.js"
-    },
-    "./basics": {
-      "import": "./basics.js"
     },
     "./defaults": {
       "import": "./defaults.js"

--- a/reader.js
+++ b/reader.js
@@ -1,5 +1,4 @@
-export default multiformats => {
-  const { CID } = multiformats
+export default CID => {
   /* eslint-disable max-depth */
   const links = function * (decoded, path = []) {
     if (typeof decoded !== 'object' || !decoded) return

--- a/test/test-errors.js
+++ b/test/test-errors.js
@@ -1,10 +1,8 @@
 'use strict'
 /* globals it */
-import createBlock from '@ipld/block'
-import multiformats from 'multiformats/basics'
+import Block from '@ipld/block'
 import assert from 'assert'
 
-const Block = createBlock(multiformats)
 const same = assert.deepStrictEqual
 const test = it
 
@@ -21,15 +19,15 @@ test('No block options', async () => {
 })
 
 test('No data or source', async () => {
-  await tryError(() => new Block({}), 'Block instances must be created with either an encode source or data')
+  await tryError(() => new Block({}), 'Cannot create block instance without cid or codec')
 })
 
 test('source only', async () => {
-  await tryError(() => new Block({ source: {} }), 'Block instances created from source objects must include desired codec')
+  await tryError(() => new Block({ source: {} }), 'Cannot create block instance without cid or codec')
 })
 
 test('data only', async () => {
-  await tryError(() => new Block({ data: Buffer.from('asdf') }), 'Block instances created from data must include cid or codec')
+  await tryError(() => new Block({ data: Buffer.from('asdf') }), 'Cannot create block instance without cid or codec')
 })
 
 test('set opts', async () => {

--- a/test/test-reader.js
+++ b/test/test-reader.js
@@ -1,12 +1,12 @@
 /* globals it */
-import Block from '@ipld/block/basics'
+import Block from '@ipld/block/defaults'
 import assert from 'assert'
 const { CID } = Block
 
 const same = assert.deepStrictEqual
 const test = it
 
-const link = CID.from('bafyreidykglsfhoixmivffc5uwhcgshx4j465xwqntbmu43nb2dzqwfvae')
+const link = CID.parse('bafyreidykglsfhoixmivffc5uwhcgshx4j465xwqntbmu43nb2dzqwfvae')
 
 const fixture = {
   n: null,


### PR DESCRIPTION
Still need to port some codecs and fill in some coverage, but all the tests are passing against `dag-cbor`.

This gets the `Block` interface up to date with @Gozala’s latest refactor. I’d like to take a moment to note how good the
work has been on that refactor. You can see it here in the diff, everywhere that we touch multiformats it’s a little bit
cleaner and also a little more explicit and even adds some features. All of this while getting rid of a lot of the harder to work
with parts of this API that came from the prior multiformats dependency injection, and we still get to keep all the same features and codec registry just hoisted to the Block interface. This was a some really great work on @Gozala’s part and it really shows.