### PR TITLE
chore: mark as archived with redirect to js-multiformats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+***This project is currently archived and is not recommended for use.*** Please see https://github.com/multiformats/js-multiformats for the latest iteration of this design pattern and for ongoing development of the basic IPLD building-blocks.
+
 # Block API
 
 The `Block` API is the single endpoint for authoring IPLD data structures. Unless you're


### PR DESCRIPTION
docs archive note should be OK for now, we can hard-deprecate via npm later on but it's possible we may come back here--there is/was a dream of having a more fully-functional block interface here that wasn't so bare-bones as multiformats, but until we have that we should be clear about our recommendations.